### PR TITLE
Fix: Adding objects to map with number value "0" creates ghost objects in UserMapping dictionary

### DIFF
--- a/objdictgen/commondialogs.py
+++ b/objdictgen/commondialogs.py
@@ -322,7 +322,7 @@ class MapVariableDialog(wx.Dialog):
         
         self.Number = wx.TextCtrl(id=ID_MAPVARIABLEDIALOGNUMBER,
               name='Number', parent=self, pos=wx.Point(0, 0),
-              size=wx.Size(0, 24), style=wx.TE_RIGHT, value='0')
+              size=wx.Size(0, 24), style=wx.TE_RIGHT, value='1')
         
         self.Spacer = wx.Panel(id=ID_MAPVARIABLEDIALOGSPACER,
               name='Spacer', parent=self, pos=wx.Point(0, 0),
@@ -354,6 +354,9 @@ class MapVariableDialog(wx.Dialog):
         if self.radioButton2.GetValue() or self.radioButton3.GetValue():
             try:
                 int(self.Number.GetValue())
+
+                if int(self.Number.GetValue()) < 1:
+                    raise ValueError, _("Number out of range")
             except:
                 error.append(_("Number"))
         if len(error) > 0:


### PR DESCRIPTION
Change default number value in MapVariableEdit dialog to 1
Add check for minimum value of at least 1 in MapVariableEdit dialog